### PR TITLE
Replace if condition with explicit rewrite rules for WP core files

### DIFF
--- a/lagoon/nginx.conf
+++ b/lagoon/nginx.conf
@@ -6,11 +6,12 @@ server {
   root /app/${WEBROOT:-};
   index  index.php;
 
-if (!-e $request_filename) {
-  rewrite /wp-admin$ $scheme://$host$uri/ permanent;
-  rewrite ^(/[^/]+)?(/wp-.*) /wp$2 last;
-  rewrite ^(/[^/]+)?(/.*\.php)$ /wp$2 last;
-}
+  # Add trailing slash to /wp-admin.
+  rewrite ^/wp-admin$ $scheme://$host$uri/ permanent;
+
+  # Rewrite access to WP core files to subdirectory.
+  rewrite ^/(xmlrpc\.php|wp-[a-z-]+\.php)$ /wp/$1 last;
+  rewrite ^/(wp-(admin|content|includes).*) /wp/$1 last;
 
   ## The 'default' location.
   location / {


### PR DESCRIPTION
There's no need for the "evil if".