### PR TITLE
Re-re-re fixing install steps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@ This repository is an example of how to use Lagoon and WordPress. It uses our lo
 2. Clone the repo.
 3. `cd` into the repo.
 4. Run `pygmy start`.
-5. Run `docker-compose build`.
-6. Run `docker-compose up -d`.
-7. You should now have a fully functional local WordPress site at [`wordpress-nginx.docker.amazee.io`](http://wordpress-nginx.docker.amazee.io)!
+5. Run `composer install`.
+6. Run `docker-compose build`.
+7. Run `docker-compose up -d`.
+8. You should now have a fully functional local WordPress site at [`wordpress-nginx.docker.amazee.io`](http://wordpress-nginx.docker.amazee.io)!
 
 ## WordPress and Composer
 


### PR DESCRIPTION
Ok, I thought I was losing my mind, but after running this installation about 50 times, it does need a `composer install` step. I figured there are a couple options - it seems to work perfectly if it's run outside of the container, and this just adds one step. The other option is to get through the `docker-compose up -d` step, then open bash in the container, then run composer install, then build again. 

I know we're *supposed* to run Composer in the container - is it that bad if we don't to make it easier? Or is this something we can fix in the installation itself?